### PR TITLE
Replaced TOTP with Phone Verification functionality

### DIFF
--- a/models/User.js
+++ b/models/User.js
@@ -93,37 +93,17 @@ UserSchema.methods.comparePassword = function(candidatePassword, cb) {
 // Send a verification token to this user
 UserSchema.methods.sendAuthyToken = function(cb) {
     var self = this;
-
-    if (!self.authyId) {
-        // Register this user if it's a new user
-        authy.register_user(self.email, self.phone, self.countryCode, 
-            function(err, response) {
-                
-            if (err || !response.user) return cb.call(self, err);
-            self.authyId = response.user.id;
-            self.save(function(err, doc) {
-                if (err || !doc) return cb.call(self, err);
-                self = doc;
-                sendToken();
-            });
-        });
-    } else {
-        // Otherwise send token to a known user
-        sendToken();
-    }
-
-    // With a valid Authy ID, send the 2FA token for this user
-    function sendToken() {
-        authy.request_sms(self.authyId, true, function(err, response) {
-            cb.call(self, err);
-        });
-    }
+    //Phone Verification Call
+    authy.phones().verification_start(self.phone, self.countryCode, 'sms', function(err, res) {
+      cb.call(self, err);
+    });
 };
 
 // Test a 2FA token
 UserSchema.methods.verifyAuthyToken = function(otp, cb) {
     var self = this;
-    authy.verify(self.authyId, otp, function(err, response) {
+    //Phone Verification Check
+    authy.phones().verification_check(self.phone, self.countryCode, otp, function (err, response) {
         cb.call(self, err, response);
     });
 };

--- a/views/index.jade
+++ b/views/index.jade
@@ -49,9 +49,9 @@ block content
         .o-grid__cell.o-grid__cell--width-20
           h2.number 2
         .o-grid__cell.o-grid__cell--width-80
-          h3 Your number is authenticated
+          h3 Your number is verified
           img.diagram
-          p You will receive a text message through Authy two-factor authentication to verify the number you entered so make sure to have your phone handy. 
+          p You will receive a text message through Authy Phone Verification to make sure to have your phone handy. 
           small We don’t want you to prank call your Aunt or Uncle after all.
 
       .inst.o-grid


### PR DESCRIPTION
Replacing Authy TOTP API Calls with Authy Phone Verification API Calls. Using PV won't register the user with the Authy service but will make sure they have the device they are registering handy.